### PR TITLE
feat(zsh): split env into .zshenv (all shells) and .zshrc (interactive only)

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -1,17 +1,25 @@
 # ~/.zshenv — sourced by EVERY zsh invocation (interactive, non-interactive,
 # login, non-login). Keep it minimal — only env vars, no prompt, no aliases.
 #
-# Why this exists: ~/.zshrc is only sourced for interactive shells. Non-
-# interactive shells (scripts, agent tools, `zsh -c`) skip it, which meant
-# `deno` and friends were unavailable outside an interactive terminal.
-#
 # Anything visual (prompt, completions, aliases) belongs in ~/.zshrc.
 
-# deno installer (idempotent — guards against duplicate PATH entries)
+# --- deno (official installer, idempotent) ---
 [[ -f "$HOME/.deno/env" ]] && . "$HOME/.deno/env"
 
-# Local user binaries (pipx, uv tools, etc.)
+# --- bun ---
+if [[ -d "$HOME/.bun" ]]; then
+  export BUN_INSTALL="$HOME/.bun"
+  [[ ":$PATH:" != *":$BUN_INSTALL/bin:"* ]] && export PATH="$BUN_INSTALL/bin:$PATH"
+fi
+
+# --- npm global ---
+[[ ":$PATH:" != *":$HOME/.npm-global/bin:"* ]] && export PATH="$HOME/.npm-global/bin:$PATH"
+
+# --- local user bins (pipx, uv tools, scripts) ---
 [[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$HOME/.local/bin:$PATH"
 
-# opencode CLI
+# --- opencode CLI ---
 [[ ":$PATH:" != *":$HOME/.opencode/bin:"* ]] && export PATH="$HOME/.opencode/bin:$PATH"
+
+# --- python venv env (no-op if missing) ---
+[[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"

--- a/.zshenv
+++ b/.zshenv
@@ -1,0 +1,17 @@
+# ~/.zshenv — sourced by EVERY zsh invocation (interactive, non-interactive,
+# login, non-login). Keep it minimal — only env vars, no prompt, no aliases.
+#
+# Why this exists: ~/.zshrc is only sourced for interactive shells. Non-
+# interactive shells (scripts, agent tools, `zsh -c`) skip it, which meant
+# `deno` and friends were unavailable outside an interactive terminal.
+#
+# Anything visual (prompt, completions, aliases) belongs in ~/.zshrc.
+
+# deno installer (idempotent — guards against duplicate PATH entries)
+[[ -f "$HOME/.deno/env" ]] && . "$HOME/.deno/env"
+
+# Local user binaries (pipx, uv tools, etc.)
+[[ ":$PATH:" != *":$HOME/.local/bin:"* ]] && export PATH="$HOME/.local/bin:$PATH"
+
+# opencode CLI
+[[ ":$PATH:" != *":$HOME/.opencode/bin:"* ]] && export PATH="$HOME/.opencode/bin:$PATH"

--- a/.zshrc
+++ b/.zshrc
@@ -115,12 +115,35 @@ source $ZSH/oh-my-zsh.sh
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-export PATH="$HOME/.deno/bin:$PATH"
 
-# opencode
-export PATH=/home/spy4x/.opencode/bin:$PATH
+# bun completions (PATH for $BUN_INSTALL/bin is set in ~/.zshenv)
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
-. "$HOME/.local/bin/env"
-
-# npm global bin
-export PATH="$HOME/.npm-global/bin:$PATH"
+# opencode completions (installed by `opencode completion`)
+#compdef opencode
+###-begin-opencode-completions-###
+#
+# yargs command completion script
+#
+# Installation: opencode completion >> ~/.zshrc
+#    or opencode completion >> ~/.zprofile on OSX.
+#
+_opencode_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  if [[ ${#reply} -gt 0 ]]; then
+    _describe 'values' reply
+  else
+    _default
+  fi
+}
+if [[ "'${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _opencode_yargs_completions "$@"
+else
+  compdef _opencode_yargs_completions opencode
+fi
+###-end-opencode-completions-###

--- a/install-shell.ts
+++ b/install-shell.ts
@@ -27,6 +27,7 @@ export class InstallShell {
   private readonly homeDir = Deno.env.get("HOME") ?? `/home/${Deno.env.get("USER")}`
   private readonly dotfilesDir = new URL(".", import.meta.url).pathname
   private readonly zshrcPath = `${this.homeDir}/.zshrc`
+  private readonly zshenvPath = `${this.homeDir}/.zshenv`
   private packageManager: PackageManager | null = null
 
   private async runCommand(command: string, description: string): Promise<boolean> {
@@ -107,27 +108,29 @@ export class InstallShell {
   }
 
   private async setupDenoPath(): Promise<boolean> {
-    const denoPathConfig = `\n# Add Deno to PATH\nexport PATH="$HOME/.deno/bin:$PATH"\n`
+    // Deno PATH is sourced via ~/.zshenv (not ~/.zshrc) so it works in
+    // non-interactive shells too. If .zshenv already exists (e.g. managed
+    // via dotfiles symlink), skip — let the tracked version win.
+    if (await fileExists(this.zshenvPath)) {
+      console.log("✅ ~/.zshenv already exists, skipping (dotfiles may manage it)")
+      return true
+    }
+
+    const zshenvContent = [
+      "# ~/.zshenv — sourced by every zsh invocation.",
+      "",
+      "# --- deno (official installer, idempotent) ---",
+      '[[ -f "$HOME/.deno/env" ]] && . "$HOME/.deno/env"',
+      "",
+    ].join("\n")
 
     try {
-      // Check if Deno PATH is already configured in .zshrc
-      if (await fileExists(this.zshrcPath)) {
-        const zshrcContent = await Deno.readTextFile(this.zshrcPath)
-        if (zshrcContent.includes('export PATH="$HOME/.deno/bin:$PATH"') || 
-            zshrcContent.includes("$HOME/.deno/bin") ||
-            zshrcContent.includes("~/.deno/bin")) {
-          console.log("✅ Deno PATH already configured")
-          return true
-        }
-      }
-
-      // Append the Deno PATH configuration to .zshrc
-      await Deno.writeTextFile(this.zshrcPath, denoPathConfig, { append: true })
-      console.log("✅ Deno PATH added to .zshrc")
+      await Deno.writeTextFile(this.zshenvPath, zshenvContent)
+      console.log("✅ ~/.zshenv created with Deno PATH")
       return true
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error)
-      console.error(`❌ Failed to setup Deno PATH: ${errorMessage}`)
+      console.error(`❌ Failed to create ~/.zshenv: ${errorMessage}`)
       return false
     }
   }
@@ -343,7 +346,7 @@ export class InstallShell {
     console.log("   ✅ Oh My Zsh framework installed")
     console.log("   ✅ Powerlevel10k theme configured")
     console.log("   ✅ Custom aliases integrated")
-    console.log("   ✅ Deno PATH configured")
+    console.log("   ✅ Deno PATH configured in ~/.zshenv")
 
     const currentShell = await this.getCurrentUserShell()
     if (currentShell?.includes("zsh")) {


### PR DESCRIPTION
## Why
PATH additions (deno, bun, opencode, .local/bin, .npm-global, python venv) lived in `~/.zshrc`. But `.zshrc` is only sourced by **interactive** zsh. Non-interactive shells (scripts, agent tools, `zsh -c`) skip it — `deno` was missing from PATH in those contexts, had to `export PATH=$HOME/.deno/bin:$PATH` manually every session.

## What
- **Add `~/.zshenv`** (new tracked file): all PATH additions + python venv source. Sourced by every zsh invocation.
- **Clean `~/.zshrc`**: drop the PATH lines (now duplicate). Preserve bun completions and opencode completions from the previously-divergent local version.
- **Update `install-shell.ts`**: `setupDenoPath` now writes `~/.zshenv` (not `.zshrc`). Idempotent — no-op if `~/.zshenv` already exists (dotfiles-managed symlink wins).
- **Symlinks**: `~/.zshrc` and `~/.zshenv` now point to tracked dotfiles.

## Files
```
.zshenv          | +25  (new)
.zshrc           | +30 -7
install-shell.ts | +17 -20
```

## Verified
```
$ zsh -c 'which deno opencode'
/home/spy4x/.deno/bin/deno
/home/spy4x/.opencode/bin/opencode

$ grep 'export PATH' ~/.zshrc   # nothing real
9:# export PATH=...    (only a comment)

$ ls -la ~/.zshrc ~/.zshenv
... ~/.zshrc  -> .../dotfiles/.zshrc
... ~/.zshenv -> .../dotfiles/.zshenv
```

## Fresh-install path
1. oh-my-zsh installer creates `~/.zshrc` template
3. `install-shell.ts` appends aliases source to `~/.zshrc`
4. `install-shell.ts` creates `~/.zshenv` with deno source (skipped if already exists)
5. User replaces `~/.zshrc`/`~/.zshenv` with dotfiles symlinks → tracked version wins