### PR TITLE
chore(zsh): drop bun + opencode completion blocks

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -115,35 +115,3 @@ source $ZSH/oh-my-zsh.sh
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
-
-# bun completions (PATH for $BUN_INSTALL/bin is set in ~/.zshenv)
-[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
-
-# opencode completions (installed by `opencode completion`)
-#compdef opencode
-###-begin-opencode-completions-###
-#
-# yargs command completion script
-#
-# Installation: opencode completion >> ~/.zshrc
-#    or opencode completion >> ~/.zprofile on OSX.
-#
-_opencode_yargs_completions()
-{
-  local reply
-  local si=$IFS
-  IFS=$'
-' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
-  IFS=$si
-  if [[ ${#reply} -gt 0 ]]; then
-    _describe 'values' reply
-  else
-    _default
-  fi
-}
-if [[ "'${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
-  _opencode_yargs_completions "$@"
-else
-  compdef _opencode_yargs_completions opencode
-fi
-###-end-opencode-completions-###


### PR DESCRIPTION
## Why
Completion stubs for bun and opencode lived in ~/.zshrc but:
- Each machine regenerates them via 'opencode completion' (drifts)
- They depend on opencode being on PATH (moved to .zshenv, but completions don't auto-trigger from there anyway)
- 32 lines of trivia in a tracked file

## What
- Removed bun completion source line (~/.bun/_bun)
- Removed opencode completion block (regeneratable via 'opencode completion >> ~/.zshrc')

## Verified
```
$ grep -E 'bun|opencode.*completions' .zshrc
$ ls -la ~/.zshrc -> .../dotfiles/.zshrc
```